### PR TITLE
Automated Changelog Entry for 0.1.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
 # Changelog
 
 <!-- <START NEW CHANGELOG ENTRY> -->
+
+## 0.1.0
+
+([Full Changelog](https://github.com/blink1073/hatch_jupyter_builder/compare/e5628cbc0407fa230ceea54cc12ef946cc1281e2...acf4d62bd0158d5344055eba9418c1c8e18b14a6))
+
+### Maintenance and upkeep improvements
+
+- Finish Initial Implementation [#3](https://github.com/blink1073/hatch_jupyter_builder/pull/3) ([@blink1073](https://github.com/blink1073))
+- Add utils tests and clean up option names [#2](https://github.com/blink1073/hatch_jupyter_builder/pull/2) ([@blink1073](https://github.com/blink1073))
+- More cleanup and front matter [#1](https://github.com/blink1073/hatch_jupyter_builder/pull/1) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/blink1073/hatch_jupyter_builder/graphs/contributors?from=2022-05-13&to=2022-05-14&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ablink1073%2Fhatch_jupyter_builder+involves%3Ablink1073+updated%3A2022-05-13..2022-05-14&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | blink1073/hatch_jupyter_builder  |
| Branch  | main  |
| Version Spec | minor |
