### PR TITLE
Automated Changelog Entry for 0.3.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.3.0
+
+([Full Changelog](https://github.com/blink1073/hatch_jupyter_builder/compare/v0.2.2...3990b4e71d439753a6b237c0570a3df8f41407ed))
+
+### Enhancements made
+
+- Add editable build kwargs [#9](https://github.com/blink1073/hatch_jupyter_builder/pull/9) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/blink1073/hatch_jupyter_builder/graphs/contributors?from=2022-05-18&to=2022-05-21&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ablink1073%2Fhatch_jupyter_builder+involves%3Ablink1073+updated%3A2022-05-18..2022-05-21&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.2.2
 
 ([Full Changelog](https://github.com/blink1073/hatch_jupyter_builder/compare/v0.2.0...880241f6537ecd3e1ad7fc202cb410dc8545f9fc))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/blink1073/hatch_jupyter_builder/graphs/contributors?from=2022-05-18&to=2022-05-18&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ablink1073%2Fhatch_jupyter_builder+involves%3Ablink1073+updated%3A2022-05-18..2022-05-18&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.2.0
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | blink1073/hatch_jupyter_builder  |
| Branch  | main  |
| Version Spec | minor |
| Since | v0.2.2 |